### PR TITLE
Collapse NodesMetrics and PodsMetrics into Metrics

### DIFF
--- a/kubesim/kubesim.go
+++ b/kubesim/kubesim.go
@@ -277,10 +277,9 @@ func (k *KubeSim) writeMetrics() error {
 		return nil
 	}
 
-	nodesMetrics, podsMetrics := metrics.BuildMetrics(k.clock, k.nodes)
-
+	metrics := metrics.BuildMetrics(k.clock, k.nodes)
 	for _, writer := range k.metricsWriters {
-		if err := writer.Write(nodesMetrics, podsMetrics); err != nil {
+		if err := writer.Write(metrics); err != nil {
 			return err
 		}
 	}

--- a/kubesim/metrics/file_writer.go
+++ b/kubesim/metrics/file_writer.go
@@ -27,19 +27,12 @@ func NewFileWriter(path string, formatter Formatter) (*FileWriter, error) {
 // FileName returns the name of file underlying this FileWriter.
 func (w *FileWriter) FileName() string { return w.file.Name() }
 
-func (w *FileWriter) Write(nodesMetrics NodesMetrics, podsMetrics PodsMetrics) error {
-	nodesStr, err := w.formatter.FormatNodesMetrics(nodesMetrics)
+func (w *FileWriter) Write(metrics Metrics) error {
+	str, err := w.formatter.Format(metrics)
 	if err != nil {
 		return err
 	}
-	w.file.WriteString(nodesStr)
-	w.file.Write([]byte{'\n'})
-
-	podsStr, err := w.formatter.FormatPodsMetrics(podsMetrics)
-	if err != nil {
-		return err
-	}
-	w.file.WriteString(podsStr)
+	w.file.WriteString(str)
 	w.file.Write([]byte{'\n'})
 
 	return nil

--- a/kubesim/metrics/json_formatter.go
+++ b/kubesim/metrics/json_formatter.go
@@ -8,19 +8,9 @@ import (
 type JSONFormatter struct {
 }
 
-// FormatNodesMetrics formats the given nodesMetrics to a JSON string, without newline at the end.
-func (j *JSONFormatter) FormatNodesMetrics(nodesMetrics NodesMetrics) (string, error) {
-	bytes, err := json.Marshal(nodesMetrics)
-	if err != nil {
-		return "", err
-	}
-
-	return string(bytes), nil
-}
-
-// FormatPodsMetrics formats the given podsMetrics to a JSON string, without newline at the end.
-func (j *JSONFormatter) FormatPodsMetrics(podsMetrics PodsMetrics) (string, error) {
-	bytes, err := json.Marshal(podsMetrics)
+// Format formats the given metrics to a JSON string, without newline at the end.
+func (j *JSONFormatter) Format(metrics Metrics) (string, error) {
+	bytes, err := json.Marshal(metrics)
 	if err != nil {
 		return "", err
 	}

--- a/kubesim/metrics/stdout_writer.go
+++ b/kubesim/metrics/stdout_writer.go
@@ -16,18 +16,12 @@ func NewStdoutWriter(formatter Formatter) StdoutWriter {
 	}
 }
 
-func (w *StdoutWriter) Write(nodesMetrics NodesMetrics, podsMetrics PodsMetrics) error {
-	nodesStr, err := w.formatter.FormatNodesMetrics(nodesMetrics)
+func (w *StdoutWriter) Write(metrics Metrics) error {
+	str, err := w.formatter.Format(metrics)
 	if err != nil {
 		return err
 	}
-	fmt.Println(nodesStr)
-
-	podsStr, err := w.formatter.FormatPodsMetrics(podsMetrics)
-	if err != nil {
-		return err
-	}
-	fmt.Println(podsStr)
+	fmt.Println(str)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #85 

New metrics looks like:

```
Metrics 2019-01-01T00:49:20+09:00
  Nodes
    node-0: Pods 1/4, memMB 2048/5120/8192, nvidia.com/gpu 0/1/1, cpu 1/3/4, Failed 0
    node-1: Pods 2/8, cpu 4/6/8, memMB 8192/10240/16384, nvidia.com/gpu 2/2/2, Failed 0
    node-2: Pods 4/16, cpu 8/12/16, memMB 16384/20480/32768, nvidia.com/gpu 4/4/4, Failed 0
  Pods
    pod-291: bound on 2019-01-01T00:48:30+09:00 at node-0, status Ok, elapsed 50 s, nvidia.com/gpu 0/1/1, cpu 1/3/4, memMB 2048/5120/6144
    pod-289: bound on 2019-01-01T00:48:10+09:00 at node-1, status Ok, elapsed 70 s, cpu 2/3/4, memMB 4096/5120/6144, nvidia.com/gpu 1/1/1
    pod-287: bound on 2019-01-01T00:47:50+09:00 at node-1, status Ok, elapsed 90 s, memMB 4096/5120/6144, nvidia.com/gpu 1/1/1, cpu 2/3/4
    pod-285: bound on 2019-01-01T00:47:30+09:00 at node-2, status Ok, elapsed 110 s, cpu 2/3/4, memMB 4096/5120/6144, nvidia.com/gpu 1/1/1
    pod-288: bound on 2019-01-01T00:48:00+09:00 at node-2, status Ok, elapsed 80 s, nvidia.com/gpu 1/1/1, cpu 2/3/4, memMB 4096/5120/6144
    pod-286: bound on 2019-01-01T00:47:40+09:00 at node-2, status Ok, elapsed 100 s, cpu 2/3/4, memMB 4096/5120/6144, nvidia.com/gpu 1/1/1
    pod-290: bound on 2019-01-01T00:48:20+09:00 at node-2, status Ok, elapsed 60 s, cpu 2/3/4, memMB 4096/5120/6144, nvidia.com/gpu 1/1/1
```

```
{"Clock":"2019-01-01T00:49:20+09:00","Nodes":{"node-0":{"Capacity":{"cpu":"4","memory":"8Gi","nvidia.com/gpu":"1","pods":"4"},"RunningPodsNum":1,"FailedPodsNum":0,"TotalResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"TotalResourceUsage":{"cpu":"1","memory":"2Gi","nvidia.com/gpu":"0"}},"node-1":{"Capacity":{"cpu":"8","memory":"16Gi","nvidia.com/gpu":"2","pods":"8"},"RunningPodsNum":2,"FailedPodsNum":0,"TotalResourceRequest":{"cpu":"6","memory":"10Gi","nvidia.com/gpu":"2"},"TotalResourceUsage":{"cpu":"4","memory":"8Gi","nvidia.com/gpu":"2"}},"node-2":{"Capacity":{"cpu":"16","memory":"32Gi","nvidia.com/gpu":"4","pods":"16"},"RunningPodsNum":4,"FailedPodsNum":0,"TotalResourceRequest":{"cpu":"12","memory":"20Gi","nvidia.com/gpu":"4"},"TotalResourceUsage":{"cpu":"8","memory":"16Gi","nvidia.com/gpu":"4"}}},"Pods":{"pod-285":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:47:30+09:00","Node":"node-2","ExecutedSeconds":110,"Status":"Ok"},"pod-286":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:47:40+09:00","Node":"node-2","ExecutedSeconds":100,"Status":"Ok"},"pod-287":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:47:50+09:00","Node":"node-1","ExecutedSeconds":90,"Status":"Ok"},"pod-288":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:48:00+09:00","Node":"node-2","ExecutedSeconds":80,"Status":"Ok"},"pod-289":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:48:10+09:00","Node":"node-1","ExecutedSeconds":70,"Status":"Ok"},"pod-290":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"BoundAt":"2019-01-01T00:48:20+09:00","Node":"node-2","ExecutedSeconds":60,"Status":"Ok"},"pod-291":{"ResourceRequest":{"cpu":"3","memory":"5Gi","nvidia.com/gpu":"1"},"ResourceLimit":{"cpu":"4","memory":"6Gi","nvidia.com/gpu":"1"},"ResourceUsage":{"cpu":"1","memory":"2Gi","nvidia.com/gpu":"0"},"BoundAt":"2019-01-01T00:48:30+09:00","Node":"node-0","ExecutedSeconds":50,"Status":"Ok"}}}
```