### PR TITLE
add_license.sh now reserves shebangs and file permission

### DIFF
--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -16,7 +16,8 @@
 
 # Adds a lincense header to files.
 
-LICENSE_LINE='Licensed under the Apache License, Version 2.0 (the "License");'
+LICENSE_LINE='Licensed under the Apache License, '
+LICENSE_LINE+='Version 2.0 (the "License");'
 
 LICENSE_HEADER=(
     'Copyright 2019 Preferred Networks, Inc.'

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -41,6 +41,8 @@ for f in ${files[@]}; do
     if ! grep "$LICENSE_LINE" $f --quiet; then
         echo "Add license header to $f"
 
+        perm=$(stat $f -c "%a")
+
         comment=""
         if [[ $f == *.go ]]; then
             comment="//"
@@ -79,5 +81,6 @@ for f in ${files[@]}; do
         fi
 
         mv $tmpfile $f
+        chmod $perm $f
     fi
 done

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Adds lincense header to files.
+# Adds a lincense header to files.
 # FIXME: Reserve shebang
 
 LICENSE_LINE='Licensed under the Apache License, Version 2.0 (the "License");'
@@ -37,26 +37,18 @@ LICENSE_HEADER=(
 
 cd $(git rev-parse --show-toplevel)
 
-function err() {
-    echo -e "\033[031m$1\033[0m"
-    exit $2
-}
-
 files=$(git ls-files | grep -v vendor | grep -e ".go" -e ".sh" -e ".py")
 for f in ${files[@]}; do
     if ! grep "$LICENSE_LINE" $f --quiet; then
         echo "Add license header to $f"
 
-        b=$(basename $f)
         comment=""
-        if [[ $b == *.go ]]; then
+        if [[ $f == *.go ]]; then
             comment="//"
-        elif [[ $b == *.sh ]]; then
+        elif [[ $f == *.sh ]]; then
             comment="#"
-        elif [[ $b == *.py ]]; then
+        else # *.py
             comment="#"
-        else
-            err "Unkown file extension" 1
         fi
 
         tmpfile=$(mktemp)
@@ -69,8 +61,7 @@ for f in ${files[@]}; do
         done
         echo >> $tmpfile
 
-        tmp2=$(mktemp)
-        cat $tmpfile $f > $tmp2
-        mv $tmp2 $f
+        cat $f >> $tmpfile
+        mv $tmpfile $f
     fi
 done

--- a/scripts/add_license.sh
+++ b/scripts/add_license.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 # Adds a lincense header to files.
-# FIXME: Reserve shebang
 
 LICENSE_LINE='Licensed under the Apache License, Version 2.0 (the "License");'
 
@@ -52,6 +51,14 @@ for f in ${files[@]}; do
         fi
 
         tmpfile=$(mktemp)
+
+        has_shebang=0
+        if [[ $(head $f -n 1) == \#!* ]]; then
+            has_shebang=1
+            echo $(head $f -n 1) >> $tmpfile
+            echo >> $tmpfile
+        fi
+
         for l in "${LICENSE_HEADER[@]}"; do
             if [ -z "$l" ]; then
                 echo "${comment}" >> $tmpfile
@@ -61,7 +68,16 @@ for f in ${files[@]}; do
         done
         echo >> $tmpfile
 
-        cat $f >> $tmpfile
+        if [ $has_shebang -eq 1 ]; then
+            if [ -z "$(head $f -n 2 | tail -n 1)" ]; then
+                tail -n +3 $f >> $tmpfile
+            else
+                tail -n +2 $f >> $tmpfile
+            fi
+        else
+            cat $f >> $tmpfile
+        fi
+
         mv $tmpfile $f
     fi
 done

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -16,7 +16,8 @@
 
 # Checks whether files have an appropriate license header.
 
-LICENSE_LINE='Licensed under the Apache License, Version 2.0 (the "License");'
+LICENSE_LINE='Licensed under the Apache License, '
+LICENSE_LINE+='Version 2.0 (the "License");'
 
 cd $(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
Tested locally against `check_license.sh`.

This PR also makes grep in `{add,check}_license.sh` not detect `LICENSE_LINE` in the scripts themselves.