### PR TITLE
Make KubeSim.Run() and AddSubmitter() thread-safe

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
 
-	kubesim "github.com/pfnet-research/k8s-cluster-simulator/pkg"
+	"github.com/pfnet-research/k8s-cluster-simulator/pkg/kubesim"
 	"github.com/pfnet-research/k8s-cluster-simulator/pkg/queue"
 	"github.com/pfnet-research/k8s-cluster-simulator/pkg/scheduler"
 )

--- a/pkg/kubesim/submitter_map/submitter_map.go
+++ b/pkg/kubesim/submitter_map/submitter_map.go
@@ -25,7 +25,7 @@ import (
 // performant than using a pair of map and sync.Mutex.
 type SubmitterMap struct {
 	inner sync.Map
-	size  int
+	size  int // track the size to avoid unnecessary computation in Len
 }
 
 // New creates a new SubmitterMap.

--- a/pkg/kubesim/submitter_map/submitter_map.go
+++ b/pkg/kubesim/submitter_map/submitter_map.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Preferred Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submittermap
+
+import (
+	"sync"
+
+	subm "github.com/pfnet-research/k8s-cluster-simulator/pkg/submitter"
+)
+
+// SubmitterMap wraps sync.Map for type-safetiness.
+// The usage of submitters map in KubeSim is read-heavy, so using sync.Map should be more
+// performant than using a pair of map and sync.Mutex.
+type SubmitterMap struct {
+	inner sync.Map
+	size  int
+}
+
+// New creates a new SubmitterMap.
+func New() *SubmitterMap {
+	return &SubmitterMap{
+		inner: sync.Map{},
+		size:  0,
+	}
+}
+
+// Len returns the number of submitters stored in this SubmitterMap.
+func (s *SubmitterMap) Len() int {
+	return s.size
+}
+
+// Load returns the submitter stored in this SubmitterMap for the key, or nil if no value is
+// present.
+// The second return value indicates whether the submitter was found.
+func (s *SubmitterMap) Load(key string) (subm.Submitter, bool) {
+	val, ok := s.inner.Load(key)
+	if !ok {
+		return nil, ok
+	}
+
+	return val.(subm.Submitter), ok
+}
+
+// Delete deletes and returns the submitter associated with the key, or returns nil if no value is
+// present.
+// The second return value indicates whether the submitter was found.
+func (s *SubmitterMap) Delete(key string) (subm.Submitter, bool) {
+	val, ok := s.Load(key)
+	if ok {
+		s.inner.Delete(key)
+		s.size--
+	}
+
+	return val, ok
+}
+
+// Store inserts the key and submitter pair to this SubmitterMap.
+// If the map had the key, the submitter is updated, and the old submitter is returned.
+// The second return value indicates the existence of the old submitter.
+func (s *SubmitterMap) Store(key string, submitter subm.Submitter) (subm.Submitter, bool) {
+	val, ok := s.Load(key)
+	if !ok {
+		s.size++
+	}
+	s.inner.Store(key, submitter)
+
+	return val, ok
+}
+
+// Range calls f sequentially for each key and submitter present in this SubmitterMap.
+// If f returns false, Range stops the iteration.
+func (s *SubmitterMap) Range(f func(key string, submitter subm.Submitter) bool) {
+	g := func(key, submitter interface{}) bool {
+		return f(key.(string), submitter.(subm.Submitter))
+	}
+
+	s.inner.Range(g)
+}

--- a/pkg/kubesim/submitter_map/submitter_map_test.go
+++ b/pkg/kubesim/submitter_map/submitter_map_test.go
@@ -1,0 +1,138 @@
+// Copyright 2019 Preferred Networks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package submittermap_test
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
+
+	"github.com/pfnet-research/k8s-cluster-simulator/pkg/clock"
+	. "github.com/pfnet-research/k8s-cluster-simulator/pkg/kubesim/submitter_map"
+	"github.com/pfnet-research/k8s-cluster-simulator/pkg/metrics"
+	"github.com/pfnet-research/k8s-cluster-simulator/pkg/submitter"
+	"github.com/stretchr/testify/assert"
+)
+
+type mySubmitter struct {
+	name string
+}
+
+func (s *mySubmitter) Submit(
+	_ clock.Clock,
+	_ algorithm.NodeLister,
+	_ metrics.Metrics) ([]submitter.Event, error) {
+	return []submitter.Event{}, nil
+}
+
+func TestSubmitterMapStore(t *testing.T) {
+	submMap := New()
+
+	submMap.Store("foo", &mySubmitter{"foo"})
+	actual := submMap.Len()
+	expected := 1
+	if actual != expected {
+		t.Errorf("got: %+v\nwant: %+v", actual, expected)
+	}
+
+	submMap.Store("bar", &mySubmitter{"bar"})
+	actual = submMap.Len()
+	expected = 2
+	if actual != expected {
+		t.Errorf("got: %+v\nwant: %+v", actual, expected)
+	}
+}
+
+func TestSubmitterMapLoad(t *testing.T) {
+	submMap := New()
+
+	_, ok := submMap.Load("foo")
+	if ok {
+		t.Error("got: true\nwant: false")
+	}
+
+	subm := mySubmitter{"foo"}
+	submMap.Store("foo", &subm)
+	actual, ok := submMap.Load("foo")
+	if !ok {
+		t.Error("got: false\nwant: true")
+	}
+	if actual.(*mySubmitter).name != subm.name {
+		t.Errorf("got: %+v\nwant: %+v", actual, subm)
+	}
+	if submMap.Len() != 1 {
+		t.Errorf("got %+v\nwant: 1", submMap.Len())
+	}
+}
+
+func TestSubmitterMapDelete(t *testing.T) {
+	submMap := New()
+
+	_, ok := submMap.Delete("foo")
+	if ok {
+		t.Error("got: true\nwant: false")
+	}
+
+	subm := mySubmitter{"foo"}
+
+	submMap.Store("foo", &subm)
+	if submMap.Len() != 1 {
+		t.Errorf("got %+v\nwant: 1", submMap.Len())
+	}
+
+	actual, ok := submMap.Delete("foo")
+	if !ok {
+		t.Error("got: false\nwant: true")
+	}
+	if actual.(*mySubmitter).name != subm.name {
+		t.Errorf("got: %+v\nwant: %+v", actual, subm)
+	}
+	if submMap.Len() != 0 {
+		t.Errorf("got %+v\nwant: 0", submMap.Len())
+	}
+
+	_, ok = submMap.Delete("foo")
+	if ok {
+		t.Error("got: true\nwant: false")
+	}
+	if submMap.Len() != 0 {
+		t.Errorf("got %+v\nwant: 0", submMap.Len())
+	}
+}
+
+func TestSubmitterMapRange(t *testing.T) {
+	submMap := New()
+
+	submMap.Store("foo", &mySubmitter{"foo"})
+	submMap.Store("bar", &mySubmitter{"bar"})
+
+	names := make([]string, 0)
+	submMap.Range(func(key string, _ submitter.Submitter) bool {
+		names = append(names, key)
+		return true
+	})
+	assert.ElementsMatch(t, names, []string{"foo", "bar"})
+
+	names = make([]string, 0)
+	submMap.Range(func(key string, _ submitter.Submitter) bool {
+		names = append(names, key)
+		return false
+	})
+
+	assert.Len(t, names, 1)
+	if names[0] != "foo" && names[0] != "bar" {
+		t.Errorf("got: %+v\nwant: \"foo\" or \"bar\"", names[0])
+	}
+}

--- a/pkg/queue/priority_queue.go
+++ b/pkg/queue/priority_queue.go
@@ -25,7 +25,7 @@ import (
 // PriorityQueue stores pods in a priority queue.
 // The pods are sorted by their priority, which can be configured by users.
 type PriorityQueue struct {
-	// PriorityQueue wraps rawPriorityQueue for type-safetiness.
+	// PriorityQueue wraps rawPriorityQueue for type-safety.
 
 	inner         rawPriorityQueue
 	nominatedPods map[string]map[string]*v1.Pod


### PR DESCRIPTION
`KubeSim.AddSubmitter()` can be called from the outside in parallel with `Run()`, so these two methods should be thread-safe.
With this PR, for the storage of submitters, a `KubeSim` instance uses `sync.Map` instead of raw `map[string]Submitter`.
The `sync.Map` is wrapped in `SubmitterMap` struct for the type-safety.

Fixes #151 