### PR TITLE
Update travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,8 @@ Please see each file for more detail.
 * [pkg/util/util_k8s.go](pkg/util/util_k8s.go)
 
 
-[build-image]: https://secure.travis-ci.org/pfnet-research/k8s-cluster-simulator.svg
-[build-link]:  http://travis-ci.org/pfnet-research/k8s-cluster-simulator
+[build-image]: https://travis-ci.com/pfnet-research/k8s-cluster-simulator.svg
+[build-link]:  http://travis-ci.com/pfnet-research/k8s-cluster-simulator
 [cov-image]:   https://coveralls.io/repos/github/pfnet-research/k8s-cluster-simulator/badge.svg?branch=master
 [cov-link]:    https://coveralls.io/github/pfnet-research/k8s-cluster-simulator?branch=master
 [godoc-image]: https://godoc.org/github.com/pfnet-research/k8s-cluster-simulator/pkg?status.svg


### PR DESCRIPTION
travis-ci.com is recommended for new users over travis-ci.org.
https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/#new-user-accounts
