### PR TITLE
Make Travis call goveralls after build success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ install:
 
 script:
 - make lint test coverage
-- goveralls -coverprofile=profile.cov -service=travis-ci
-- make e2e
+- make e2e # don't merge with the above line
 - python3 ./scripts/license/check.py -v
 - python3 ./scripts/check_dep_list.py -v
+
+after_success:
+- goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
Invoking `goveralls` in forked repos breaks CI.