### PR TITLE
Fix license scripts

### DIFF
--- a/scripts/license/add.py
+++ b/scripts/license/add.py
@@ -16,22 +16,24 @@
 Adds a license header to files.
 """
 
+import os
 from pathlib import Path
 import subprocess
 
 from license_header import license_header, has_license_header
 
-PROJECT_ROOT = Path(subprocess.check_output(
-    "git rev-parse --show-toplevel".split()).strip().decode("utf-8"))
+PROJECT_ROOT = subprocess.check_output(
+    "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
+target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT) if d != "vendor"]
 
 
 def main(verbose=False):
-    add(PROJECT_ROOT.glob("*[!vendor]/**/*_k8s.go"),
-        license_header("//", True), verbose)
-    add([p for p in PROJECT_ROOT.glob("*[!vendor]/**/*.go")
-         if p.name[-7:] != "_k8s.go"], license_header("//"), verbose)
-    add(PROJECT_ROOT.glob("*[!vendor]/**/*.py"), license_header("#"), verbose)
-    add(PROJECT_ROOT.glob("*[!vendor]/**/*.sh"), license_header("#"), verbose)
+    for d in target_dirs:
+        add(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
+        add([p for p in Path(d).glob("**/*.go")
+             if p.name[-7:] != "_k8s.go"], license_header("//"), verbose)
+        add(Path(d).glob("**/*.py"), license_header("#"), verbose)
+        add(Path(d).glob("**/*.sh"), license_header("#"), verbose)
 
 
 def add(paths, license_header, verbose):

--- a/scripts/license/add.py
+++ b/scripts/license/add.py
@@ -24,10 +24,15 @@ from license_header import license_header, has_license_header
 
 PROJECT_ROOT = subprocess.check_output(
     "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
-target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT) if d != "vendor"]
+target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT)
+               if d != "vendor" and os.path.isdir(os.path.join(PROJECT_ROOT, d))]
 
 
 def main(verbose=False):
+    add(Path(PROJECT_ROOT).glob("*.go"), license_header("//"), verbose)
+    add(Path(PROJECT_ROOT).glob("*.py"), license_header("#"), verbose)
+    add(Path(PROJECT_ROOT).glob("*.sh"), license_header("#"), verbose)
+
     for d in target_dirs:
         add(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
         add([p for p in Path(d).glob("**/*.go")

--- a/scripts/license/add.py
+++ b/scripts/license/add.py
@@ -16,29 +16,28 @@
 Adds a license header to files.
 """
 
-import os
 from pathlib import Path
 import subprocess
 
 from license_header import license_header, has_license_header
 
-PROJECT_ROOT = subprocess.check_output(
-    "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
-target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT)
-               if d != "vendor" and os.path.isdir(os.path.join(PROJECT_ROOT, d))]
+PROJECT_ROOT = Path(subprocess.check_output(
+    "git rev-parse --show-toplevel".split()).strip().decode("utf-8"))
 
 
 def main(verbose=False):
-    add(Path(PROJECT_ROOT).glob("*.go"), license_header("//"), verbose)
-    add(Path(PROJECT_ROOT).glob("*.py"), license_header("#"), verbose)
-    add(Path(PROJECT_ROOT).glob("*.sh"), license_header("#"), verbose)
+    add(PROJECT_ROOT.glob("*.go"), license_header("//"), verbose)
+    add(PROJECT_ROOT.glob("*.py"), license_header("#"), verbose)
+    add(PROJECT_ROOT.glob("*.sh"), license_header("#"), verbose)
 
-    for d in target_dirs:
-        add(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
-        add([p for p in Path(d).glob("**/*.go")
-             if not p.name.endswith("_k8s.go")], license_header("//"), verbose)
-        add(Path(d).glob("**/*.py"), license_header("#"), verbose)
-        add(Path(d).glob("**/*.sh"), license_header("#"), verbose)
+    for p in PROJECT_ROOT.glob("*"):
+        if p.name == "vendor" or not p.is_dir():
+            continue
+        add(p.glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
+        add([pp for pp in p.glob("**/*.go")
+             if not pp.name.endswith("_k8s.go")], license_header("//"), verbose)
+        add(p.glob("**/*.py"), license_header("#"), verbose)
+        add(p.glob("**/*.sh"), license_header("#"), verbose)
 
 
 def add(paths, license_header, verbose):

--- a/scripts/license/add.py
+++ b/scripts/license/add.py
@@ -30,7 +30,7 @@ def main(verbose=False):
     add(PROJECT_ROOT.glob("*.py"), license_header("#"), verbose)
     add(PROJECT_ROOT.glob("*.sh"), license_header("#"), verbose)
 
-    for p in PROJECT_ROOT.glob("*"):
+    for p in PROJECT_ROOT.iterdir():
         if p.name == "vendor" or not p.is_dir():
             continue
         add(p.glob("**/*_k8s.go"), license_header("//", modification=True), verbose)

--- a/scripts/license/add.py
+++ b/scripts/license/add.py
@@ -36,7 +36,7 @@ def main(verbose=False):
     for d in target_dirs:
         add(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
         add([p for p in Path(d).glob("**/*.go")
-             if p.name[-7:] != "_k8s.go"], license_header("//"), verbose)
+             if not p.name.endswith("_k8s.go")], license_header("//"), verbose)
         add(Path(d).glob("**/*.py"), license_header("#"), verbose)
         add(Path(d).glob("**/*.sh"), license_header("#"), verbose)
 

--- a/scripts/license/check.py
+++ b/scripts/license/check.py
@@ -24,11 +24,16 @@ from license_header import license_header, has_license_header
 
 PROJECT_ROOT = subprocess.check_output(
     "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
-target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT) if d != "vendor"]
+target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT)
+               if d != "vendor" and os.path.isdir(os.path.join(PROJECT_ROOT, d))]
 
 
 def main(verbose=False):
     ok = True
+
+    ok &= check(Path(PROJECT_ROOT).glob("*.go"), license_header("//"), verbose)
+    ok &= check(Path(PROJECT_ROOT).glob("*.py"), license_header("#"), verbose)
+    ok &= check(Path(PROJECT_ROOT).glob("*.sh"), license_header("#"), verbose)
 
     for d in target_dirs:
         ok &= check(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)

--- a/scripts/license/check.py
+++ b/scripts/license/check.py
@@ -16,31 +16,30 @@
 Checks whether files have an appropriate license header.
 """
 
-import os
 from pathlib import Path
 import subprocess
 
 from license_header import license_header, has_license_header
 
-PROJECT_ROOT = subprocess.check_output(
-    "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
-target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT)
-               if d != "vendor" and os.path.isdir(os.path.join(PROJECT_ROOT, d))]
+PROJECT_ROOT = Path(subprocess.check_output(
+    "git rev-parse --show-toplevel".split()).strip().decode("utf-8"))
 
 
 def main(verbose=False):
     ok = True
 
-    ok &= check(Path(PROJECT_ROOT).glob("*.go"), license_header("//"), verbose)
-    ok &= check(Path(PROJECT_ROOT).glob("*.py"), license_header("#"), verbose)
-    ok &= check(Path(PROJECT_ROOT).glob("*.sh"), license_header("#"), verbose)
+    ok &= check(PROJECT_ROOT.glob("*.go"), license_header("//"), verbose)
+    ok &= check(PROJECT_ROOT.glob("*.py"), license_header("#"), verbose)
+    ok &= check(PROJECT_ROOT.glob("*.sh"), license_header("#"), verbose)
 
-    for d in target_dirs:
-        ok &= check(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
-        ok &= check([p for p in Path(d).glob("**/*.go")
-            if not p.name.endswith("_k8s.go")], license_header("//"), verbose)
-        ok &= check(Path(d).glob("**/*.py"), license_header("#"), verbose)
-        ok &= check(Path(d).glob("**/*.sh"), license_header("#"), verbose)
+    for p in PROJECT_ROOT.glob("*"):
+        if p.name == "vendor" or not p.is_dir():
+            continue
+        ok &= check(p.glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
+        ok &= check([pp for pp in p.glob("**/*.go")
+            if not pp.name.endswith("_k8s.go")], license_header("//"), verbose)
+        ok &= check(p.glob("**/*.py"), license_header("#"), verbose)
+        ok &= check(p.glob("**/*.sh"), license_header("#"), verbose)
 
     return 0 if ok else 1
 

--- a/scripts/license/check.py
+++ b/scripts/license/check.py
@@ -16,29 +16,26 @@
 Checks whether files have an appropriate license header.
 """
 
+import os
 from pathlib import Path
 import subprocess
 
 from license_header import license_header, has_license_header
 
-PROJECT_ROOT = Path(subprocess.check_output(
-    "git rev-parse --show-toplevel".split()).strip().decode("utf-8"))
+PROJECT_ROOT = subprocess.check_output(
+    "git rev-parse --show-toplevel".split()).strip().decode("utf-8")
+target_dirs = [os.path.join(PROJECT_ROOT, d) for d in os.listdir(PROJECT_ROOT) if d != "vendor"]
 
 
 def main(verbose=False):
     ok = True
 
-    ok &= check(
-        PROJECT_ROOT.glob("./*[!vendor]/**/*_k8s.go"),
-        license_header("//", modification=True), verbose)
-    ok &= check(
-        [p for p in PROJECT_ROOT.glob(
-            "./*[!vendor]/**/*.go") if p.name[-7:] != "_k8s.go"],
-        license_header("//"), verbose)
-    ok &= check(
-        PROJECT_ROOT.glob("./*[!vendor]/**/*.py"), license_header("#"), verbose)
-    ok &= check(
-        PROJECT_ROOT.glob("./*[!vendor]/**/*.sh"), license_header("#"), verbose)
+    for d in target_dirs:
+        ok &= check(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
+        ok &= check([p for p in Path(d).glob("**/*.go")
+            if p.name[-7:] != "_k8s.go"], license_header("//"), verbose)
+        ok &= check(Path(d).glob("**/*.py"), license_header("#"), verbose)
+        ok &= check(Path(d).glob("**/*.sh"), license_header("#"), verbose)
 
     return 0 if ok else 1
 

--- a/scripts/license/check.py
+++ b/scripts/license/check.py
@@ -32,7 +32,7 @@ def main(verbose=False):
     ok &= check(PROJECT_ROOT.glob("*.py"), license_header("#"), verbose)
     ok &= check(PROJECT_ROOT.glob("*.sh"), license_header("#"), verbose)
 
-    for p in PROJECT_ROOT.glob("*"):
+    for p in PROJECT_ROOT.iterdir():
         if p.name == "vendor" or not p.is_dir():
             continue
         ok &= check(p.glob("**/*_k8s.go"), license_header("//", modification=True), verbose)

--- a/scripts/license/check.py
+++ b/scripts/license/check.py
@@ -38,7 +38,7 @@ def main(verbose=False):
     for d in target_dirs:
         ok &= check(Path(d).glob("**/*_k8s.go"), license_header("//", modification=True), verbose)
         ok &= check([p for p in Path(d).glob("**/*.go")
-            if p.name[-7:] != "_k8s.go"], license_header("//"), verbose)
+            if not p.name.endswith("_k8s.go")], license_header("//"), verbose)
         ok &= check(Path(d).glob("**/*.py"), license_header("#"), verbose)
         ok &= check(Path(d).glob("**/*.sh"), license_header("#"), verbose)
 


### PR DESCRIPTION
I found the current license scripts don't work if we have other top directories like `cmd` because the patter matching `*[!vendor]` is not correct syntax for the expected behavior of excluding `vendor` directory.